### PR TITLE
Add simple examples for iceberg-data, Row-level Java API to Site doc.

### DIFF
--- a/site/docs/api.md
+++ b/site/docs/api.md
@@ -43,6 +43,8 @@ Tables also provide `refresh` to update the table to the latest version, and exp
 
 ### Scanning
 
+#### File level
+
 Iceberg table scans start by creating a `TableScan` object with `newScan`.
 
 ```java
@@ -70,6 +72,27 @@ Iterable<CombinedScanTask> tasks = scan.planTasks();
 
 Use `asOfTime` or `useSnapshot` to configure the table snapshot for time travel queries.
 
+#### Row level
+
+Iceberg table scans start by creating a `ScanBuilder` object with `IcebergGenerics.read`.
+
+```java
+ScanBuilder scanBuilder = IcebergGenerics.read(table)
+```
+
+To configure a scan, call `where` and `select` on the `ScanBuilder` to get a new `ScanBuilder` with those changes.
+
+```java
+scanBuilder.where(Expressions.equal("id", 5))
+```
+
+When a scan is configured, call method `build` to execute scan. `build` return `CloseableIterable<Record>`
+
+```java
+Iterable<Record> result = IcebergGenerics.read(table)
+        .where(Expressions.lessThan("id", 5))
+        .build();
+```
 
 ### Update operations
 


### PR DESCRIPTION
Fix for https://github.com/apache/iceberg/issues/3082
iceberg-data, Row-level Java API do not have any examples or descriptions on-site doc. 
So I add few very simple examples here.